### PR TITLE
Switch deleteCardNotify to native "composed" DOM event

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,8 +37,16 @@ the link will open in a new tab. If it is relative it will open in the same tab.
 
 ## Removing Card
 
-When the remove card button is clicked a `deleteCardNotify` event is fired where `event.detail`
-as the UID of the card.
+`myuw-compact-card`s have a contextual menu with a delete menu item. When users
+attempt to delete the card, this web component fires a custom `deleteCardNotify`
+**DOM event** on the `myuw-compact-card` element where `event.detail` is the UID
+of the card.
+
+This event is both `bubbles` and `composed` so it will bubble up into the parent
+document (beyond this web component's shadow DOM).
+
+Handling that event to actually delete the card is an exercise left to the
+implementer.
 
 ```javascript
   const el = document.getElementById('my-card');

--- a/src/app/compact-card/compact-card.component.ts
+++ b/src/app/compact-card/compact-card.component.ts
@@ -4,7 +4,8 @@ import {
   Input,
   Output,
   EventEmitter,
-  Inject
+  Inject,
+  ElementRef
 } from '@angular/core';
 import { DOCUMENT } from '@angular/common';
 import { fas } from '@fortawesome/free-solid-svg-icons';
@@ -37,13 +38,12 @@ export class CompactCardComponent {
 
   public svgIconUrl;
 
-  @Output() deleteCardNotify = new EventEmitter<string>();
-
   constructor(
     @Inject(DOCUMENT) private document: any,
     private matIconRegistry: MatIconRegistry,
     private domSanitizer: DomSanitizer,
-    private library: FaIconLibrary
+    private library: FaIconLibrary,
+    private el: ElementRef
   ) {
     library.addIconPacks(fas);
   }
@@ -52,7 +52,13 @@ export class CompactCardComponent {
    * Notify the page using the web component that the user clicked the delete button.
    */
   handleCardDelete() {
-    this.deleteCardNotify.emit(this.uid);
+    this.el.nativeElement
+      .dispatchEvent(new CustomEvent('deleteCardNotify', {
+        detail: this.uid,
+        bubbles: true,
+        composed: true
+      }));
+
   }
 
   /**

--- a/src/index.html
+++ b/src/index.html
@@ -49,20 +49,7 @@
     >
     </myuw-compact-card>
     <script>
-      const fontawesomeTestElement = document.getElementById('fontawesome-test');
-      fontawesomeTestElement.addEventListener('deleteCardNotify', e => {
-        console.log(e.detail);
-      });
-      const materialTestElement = document.getElementById('material-test');
-      materialTestElement.addEventListener('deleteCardNotify', e => {
-        console.log(e.detail);
-      });
-      const svgTestElement = document.getElementById('svg-test');
-      svgTestElement.addEventListener('deleteCardNotify', e => {
-        console.log(e.detail);
-      });
-      const anotherSvgTestElement = document.getElementById('another-svg-test');
-      anotherSvgTestElement.addEventListener('deleteCardNotify', e => {
+      document.addEventListener('deleteCardNotify', e => {
         console.log(e.detail);
       });
     </script>


### PR DESCRIPTION
Switches the `deleteCardNotify` event fired on attempt to delete card to be a native DOM event with `bubbles` and `composed` set to that it bubbles up in the parent document.