### PR TITLE
Link to the app details page from the widget action menu

### DIFF
--- a/src/app/compact-card/compact-card.component.html
+++ b/src/app/compact-card/compact-card.component.html
@@ -19,6 +19,11 @@
 
 <!-- Menu -->
 <mat-menu #menu="matMenu" class="custom-menu-panel">
+  <!-- About -->
+  <a mat-menu-item class="menu-item" href="/web/apps/details/{{uid}}">
+    <mat-icon>info</mat-icon>
+    About {{title}}
+  </a>
   <!-- Remove widget button -->
   <button mat-menu-item class="menu-item" (click)="handleCardDelete()">
     <mat-icon>delete</mat-icon>


### PR DESCRIPTION
Especially since the context menu no longer itself includes the app description, link to a page that does.