### PR TITLE
ignore premature bind of literal AngularJS expression as SVG URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,15 @@ implementer.
   Without this bit of complexity, 
   `FontAwesome: Could not find icon with iconName={{widget.faIcon |`
   littered the logs where `uPortal-app-framework` uses this web component.
++ Likewise, ignores `svg-icon` attribute when its value includes `{`.
+  This is likewise so that an AngularJS application can naively invoke this web
+  component feeding the `svg-icon` attribute an AngularJS expression, with this
+  web component ignoring the attribute until the AngularJS expression resolves.
+  Without this bit of complexity,
+
+```console
+Error retrieving icon: Http failure response for .../web/%7B%7B::widget.iconUrl%7D%7D: 404 Not Found
+```
 
 ## Local Development
 

--- a/src/app/compact-card/compact-card.component.ts
+++ b/src/app/compact-card/compact-card.component.ts
@@ -32,8 +32,10 @@ export class CompactCardComponent {
    */
   @Input("svgIcon")
   set svgIcon(url) {
-    this.svgIconUrl = url;
-    this.createCustomIcon(url);
+    if (! url.startsWith("{")) { // ignore AngularJS expression premature bind
+      this.svgIconUrl = url;
+      this.createCustomIcon(url);
+    }
   }
 
   public svgIconUrl;


### PR DESCRIPTION
Bug in downstream where prematurely binds literal AngularJS expression syntax rather than the value of the evaluated expression.

`Error retrieving icon: Http failure response for https://predev.my.wisc.edu/web/%7B%7B::widget.iconUrl%7D%7D: 404 Not Found`

 This should make the setter ignore the expression until it binds to a value.

Similar to #1 wherein `fa-icon` ignores unbound AngularJS expressions.