### PR TITLE
Show loading indicator while waiting for card to load

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -8,6 +8,7 @@ import { MatCardModule } from '@angular/material/card';
 import { MatButtonModule } from '@angular/material/button';
 import { MatMenuModule } from '@angular/material/menu';
 import { MatIconModule } from '@angular/material/icon';
+import {MatProgressBarModule} from '@angular/material/progress-bar';
 import { MatTooltipModule } from '@angular/material/tooltip';
 import { MatToolbarModule } from '@angular/material/toolbar';
 
@@ -25,6 +26,7 @@ import { FontAwesomeModule } from '@fortawesome/angular-fontawesome';
     MatIconModule,
     MatTooltipModule,
     MatToolbarModule,
+    MatProgressBarModule,
     FontAwesomeModule
   ],
   declarations: [CompactCardComponent],

--- a/src/app/compact-card/compact-card.component.html
+++ b/src/app/compact-card/compact-card.component.html
@@ -10,7 +10,10 @@
       <mat-icon *ngIf="svgIconUrl" class="widget-icon" svgIcon="customSvgIcon"></mat-icon>
       <mat-icon *ngIf="mdIcon" class="widget-icon">{{ mdIcon }}</mat-icon>
       <fa-icon *ngIf="faIcon && !faIcon.includes('{')" [classes]="['widget-icon']" [icon]="['fas', faIcon]"></fa-icon>
-      <mat-icon *ngIf="!svgIconUrl && !mdIcon && !faIcon" class="widget-icon">star</mat-icon>
+      <mat-icon *ngIf="title && !svgIconUrl && !mdIcon && !faIcon"
+        class="widget-icon">star
+      </mat-icon>
+
     </div>
     <div class="title-container">
       <h4>{{ title }}</h4>

--- a/src/index.html
+++ b/src/index.html
@@ -42,7 +42,7 @@
     >
     </myuw-compact-card>
     <myuw-compact-card
-      title="Suppresses fa-icon when contains {"
+      title="Suppresses fa-icon when contains curly brace"
       uid="no-brackets"
       url="/star"
       fa-icon="{{angularJS expression not yet evaluated}}"

--- a/src/index.html
+++ b/src/index.html
@@ -54,6 +54,7 @@
       url="/star"
   >
   </myuw-compact-card>
+  <myuw-compact-card></myuw-compact-card>
     <script>
       document.addEventListener('deleteCardNotify', e => {
         console.log(e.detail);


### PR DESCRIPTION
Observed in predev that there can be a sizeable delay while the home page loads, which currently looks like a bunch of blank cards.  This adds a loading indicator progress bar while the card's loading.

This might be too obnoxious, but it seems like some kind of loading indicator is warranted.